### PR TITLE
Fixed navbar routing

### DIFF
--- a/views/partial/header.ejs
+++ b/views/partial/header.ejs
@@ -34,7 +34,7 @@
 					<a class="nav-link" href="/">Home <span class="sr-only">(current)</span></a>
 				</li>
 				<li class="nav-item">
-					<a class="nav-link" href="#aboutid">about</a>
+					<a class="nav-link" href="/#aboutid">about</a>
 				</li>
 				<li class="nav-item">
 					<a class="nav-link" href="/countrywise">Country wise</a>
@@ -46,10 +46,10 @@
 					<a class="nav-link" href="/indiatimeline">India's Timeline</a>
 				</li>
 				<li class="nav-item">
-					<a class="nav-link" href="#sympid">Symptoms</a>
+					<a class="nav-link" href="/#sympid">Symptoms</a>
 				</li>
 				<li class="nav-item">
-					<a class="nav-link" href="#preventid">Prevention</a>
+					<a class="nav-link" href="/#preventid">Prevention</a>
 				</li>
 				<li class="nav-item">
 					<a class="nav-link" href="/developer">Developer</a>


### PR DESCRIPTION
Now when clicking on links 'about', 'symptoms', and 'prevention' while not on the homepage will route you to the correct part of the home page.

Fixed #2 