### PR TITLE
[Fix] Api declaration error

### DIFF
--- a/public/js/home.js
+++ b/public/js/home.js
@@ -43,3 +43,6 @@ function get(){
     var preloader = document.getElementById('loader');
     preloader.style.display = 'none';
 }
+
+// page load
+get()

--- a/public/js/indiacovid.js
+++ b/public/js/indiacovid.js
@@ -48,3 +48,5 @@ function get(){
     preloader.style.display = 'none';
 }
 
+// page load
+get()

--- a/public/js/statewise.js
+++ b/public/js/statewise.js
@@ -40,3 +40,5 @@ function get(){
     preloader.style.display = 'none';
 }
 
+// page load
+get()

--- a/public/js/worldcovid.js
+++ b/public/js/worldcovid.js
@@ -53,3 +53,5 @@ function get(){
     preloader.style.display = 'none';
 }
 
+// page load
+get()

--- a/views/pages/developer.ejs
+++ b/views/pages/developer.ejs
@@ -108,8 +108,9 @@
     </div>
 </div>
 
-
-
-
+<script>
+    var preloader = document.getElementById('loader');
+    preloader.style.display = 'none';
+</script>
 
 <%- include('../partial/footer') %>

--- a/views/pages/donate.ejs
+++ b/views/pages/donate.ejs
@@ -13,7 +13,9 @@
     </div>
 </div>
 
-
-
+<script>
+    var preloader = document.getElementById('loader');
+    preloader.style.display = 'none';
+</script>
 
 <%- include('../partial/footer') %>

--- a/views/pages/home.ejs
+++ b/views/pages/home.ejs
@@ -246,7 +246,6 @@
     
 </div>
 
-
 <!-- <div class="container-fluid pt-5 pb-5" id="about" >
     <div class="section_header text-center mb-5 mt-4">
         <h1>Coronavirus prevention</h1>
@@ -276,7 +275,6 @@
     </div>
 </div> -->
 
-
-
+<script src="/js/home.js"></script>
 
 <%- include('../partial/footer') %>

--- a/views/partial/footer.ejs
+++ b/views/partial/footer.ejs
@@ -13,8 +13,6 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/waypoints/4.0.1/jquery.waypoints.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Counter-Up/1.0.0/jquery.counterup.min.js"></script>
 <script src="/js/index.js"></script>
-
-<script src="/js/home.js"></script>
     
     </body>
 </html>

--- a/views/partial/header.ejs
+++ b/views/partial/header.ejs
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="/css/style.css">
     <title><%= title %></title>
 </head>
-<body onload="get()">
+<body>
 
 	<div id="loader"></div>
 


### PR DESCRIPTION
Fixes issue #8
- remove onload get() from body in header.ejs
- add get() line on each js file instead (at end)
- remove loading `home.js` on every route in `footer.ejs`
- add `home.js` only to `home.ejs`
- hide loader on load on developer and donate pages

This fixes the multiple api declaration error. `home.js` runs on every route and that duplicates the api declaration.
More efficient to run the script as needed on each route.

The Donate and Developer pages need the loader to be hidden after the page loads. 
Added to the end of `developer.ejs` and `donate.ejs`:

```
<script>
    var preloader = document.getElementById('loader');
    preloader.style.display = 'none';
</script>
```
